### PR TITLE
Fixed goblin width photo

### DIFF
--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -13,7 +13,7 @@ const Home = () => {
         </Grid>
 
         <Grid md={6} item>
-          <Box component="img" width={600} height={300} src={logo} />
+          <Box component="img" max-width={"100%"} src={logo} />
         </Grid>
       </Grid>
     </Layout>


### PR DESCRIPTION
Removed the fixed width and height of the home page goblin photo and set maximum width of parent element.